### PR TITLE
Add additional tags step to release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,12 @@ jobs:
     - name: Smoke Test
       run: IMAGE_NAME=${{ steps.apko.outputs.digest }} ./test.sh
 
+    - name: Additional tags
+      uses: distroless/actions/tag@main
+      with:
+        distroless_image: ghcr.io/${{ github.repository }}
+        docker_image: "golang"
+
     # Post to slack when things fail.
     - if: ${{ failure() }}
       uses: rtCamp/action-slack-notify@v2.2.0


### PR DESCRIPTION
This will start tagging the Go image with additional version tags based on DockerHub